### PR TITLE
Update index.html font link to use double quotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Starter Kit</title>
     <link rel="stylesheet" href="./styles.css">
-    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic" rel="stylesheet" type="text/css">
 
     <!-- This snippet is used to setup Simpla on your site -->
     <script src="https://app.simpla.io"></script>


### PR DESCRIPTION
Avoid htmlhint error by using double quotes instead of single quotes